### PR TITLE
feat (delivery): [containerapps] prep service for Container Apps environment

### DIFF
--- a/src/shipping/delivery/Fabrikam.DroneDelivery.DeliveryService/Startup.cs
+++ b/src/shipping/delivery/Fabrikam.DroneDelivery.DeliveryService/Startup.cs
@@ -50,7 +50,6 @@ namespace Fabrikam.DroneDelivery.DeliveryService
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
             // Configure AppInsights
-            services.AddApplicationInsightsKubernetesEnricher();
             services.AddApplicationInsightsTelemetry(Configuration);
 
             // Add health check

--- a/workload-stamp.json
+++ b/workload-stamp.json
@@ -900,6 +900,10 @@
             "value": "[variables('deliveryCosmosDbName')]",
             "type": "string"
         },
+        "deliveryRedisName": {
+            "value": "[variables('deliveryRedisName')]",
+            "type": "string"
+        },
         "droneSchedulerCosmosDbName": {
             "value": "[variables('droneSchedulerCosmosDbName')]",
             "type": "string"


### PR DESCRIPTION
related: #511224

## WHY

we want to start running the delivery service app in a Azure Container App instance. Currently delivery service is instrumented to be contextualized in k8s clusters and we also need some details from Redis instance. 

## WHAT Changed?

- stop adding the k8s enricher
- output the reds name

## HOW to test?

It is possible to run the delivery service locally without issues.