### PR TITLE
feat (dronescheduler): [containerapps] prep service for Container Apps environment

### DIFF
--- a/src/shipping/dronescheduler/Fabrikam.DroneDelivery.DroneSchedulerService/Startup.cs
+++ b/src/shipping/dronescheduler/Fabrikam.DroneDelivery.DroneSchedulerService/Startup.cs
@@ -37,7 +37,6 @@ namespace Fabrikam.DroneDelivery.DroneSchedulerService
             services.AddFeatureManagement();
 
             // Configure AppInsights
-            services.AddApplicationInsightsKubernetesEnricher();
             services.AddApplicationInsightsTelemetry(Configuration);
 
             // Add framework services.


### PR DESCRIPTION
related: #522702

## WHY

we want to start running the dronescheduler service app in an Azure Container App instance. Currently this service is instrumented to be contextualized in k8s clusters. 

## WHAT Changes?

- stop adding the k8s enricher

## HOW to test?

It is possible to run the dronescheduler service locally without issues.