### PR TITLE
feat (workflow): [containerapps] prep service for Container Apps environment 

### DIFF
--- a/src/shipping/workflow/Fabrikam.Workflow.Service/ServiceStartup.cs
+++ b/src/shipping/workflow/Fabrikam.Workflow.Service/ServiceStartup.cs
@@ -23,7 +23,6 @@ namespace Fabrikam.Workflow.Service
             services.AddOptions();
 
             // Configure AppInsights
-            services.AddApplicationInsightsKubernetesEnricher();
             services.AddApplicationInsightsTelemetry(context.Configuration);
 
             services.Configure<WorkflowServiceOptions>(context.Configuration);

--- a/workload-stamp.json
+++ b/workload-stamp.json
@@ -924,6 +924,10 @@
             "value": "[variables('workflowKeyVaultName')]",
             "type": "string"
         },
+        "workflowServiceAccessKeyName": {
+          "value": "[variables('workflowServiceAccessKeyName')]",
+          "type": "string"
+        },
         "deliveryKeyVaultName": {
             "value": "[variables('deliveryKeyVaultName')]",
             "type": "string"


### PR DESCRIPTION
related: #522704

## WHY

we want to start running the workflow service app in an Azure Container App instance. Currently this service is instrumented to be contextualized in k8s clusters. 

## WHAT Changes?

- stop adding the k8s enricher

## HOW to test?

It is possible to run the workflow service locally without issues.