### PR TITLE
feat (package): [containerapps] prep service for Container Apps environment 

### DIFF
--- a/src/shipping/package/package.json
+++ b/src/shipping/package/package.json
@@ -31,7 +31,7 @@
     "koa-compress": "^3.0.0",
     "mongodb": "3.2.1",
     "swagger-jsdoc": "^4.0.0",
-    "winston": "^3.2.1"
+    "winston": "3.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
related: #522703

## WHY

we want to start running the package service app in an Azure Container App instance and we find a build issue using piston higher than v3.2.1. 

## WHAT Changed?

- keep Winston in v3.2.1

## HOW to test?

It is possible to build the package service locally without issues.