### PR TITLE
Fix the package service's ./up.sh command

### DIFF
--- a/src/shipping/package/docker-compose.dev.yaml
+++ b/src/shipping/package/docker-compose.dev.yaml
@@ -17,7 +17,7 @@ services:
      - NODE_ENV=development
      - CONNECTION_STRING=mongodb://packagedb:27017/local
      - COLLECTION_NAME=packages
-     - LOG_LEVEL = "debug"
+     - LOG_LEVEL=debug
     networks:
       dronedelivery:
         aliases:


### PR DESCRIPTION
The LOG_LEVEL environment variable was not being set properly, which was causing a blocking error in executing ./up.sh on latest docker compose tooling.  This fixes that issue.