### PR TITLE
Ingestion - Package versions

### DIFF
--- a/src/shipping/ingestion/pom.xml
+++ b/src/shipping/ingestion/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.4</version>
+		<version>3.5.0</version>
 	</parent>
 
 	<properties>
@@ -49,7 +49,18 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 		</dependency>
-
+		<dependency>
+		  <groupId>io.micrometer</groupId>
+		  <artifactId>micrometer-tracing</artifactId>
+		</dependency>
+		<dependency>
+		  <groupId>io.micrometer</groupId>
+		  <artifactId>micrometer-tracing-bridge-otel</artifactId>
+		</dependency>
+		<dependency>
+		  <groupId>io.opentelemetry</groupId>
+		  <artifactId>opentelemetry-exporter-otlp</artifactId>
+		</dependency>
 		<dependency>
 		    <groupId>org.springframework.boot</groupId>
 		    <artifactId>spring-boot-starter-actuator</artifactId>
@@ -76,7 +87,7 @@
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>applicationinsights-web</artifactId>
-            <version>2.6.4</version>
+            <version>3.7.3</version>
         </dependency>
 
 		<dependency>

--- a/src/shipping/ingestion/src/main/java/com/fabrikam/dronedelivery/ingestion/util/ServiceBusTracingImpl.java
+++ b/src/shipping/ingestion/src/main/java/com/fabrikam/dronedelivery/ingestion/util/ServiceBusTracingImpl.java
@@ -16,7 +16,6 @@ import com.microsoft.applicationinsights.telemetry.Duration;
 import com.microsoft.applicationinsights.telemetry.RemoteDependencyTelemetry;
 import com.microsoft.applicationinsights.telemetry.RequestTelemetry;
 import com.microsoft.applicationinsights.web.internal.ThreadContext;
-import com.microsoft.applicationinsights.web.internal.correlation.TelemetryCorrelationUtils;
 import com.microsoft.azure.servicebus.IMessage;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -108,8 +107,7 @@ public class ServiceBusTracingImpl implements ServiceBusTracing {
 		String target,
 		Duration duration,
 		boolean successful) {
-		String dependencyId = TelemetryCorrelationUtils
-								.generateChildDependencyId();
+	
 
 		RemoteDependencyTelemetry dependencyTelemetry =
 			new RemoteDependencyTelemetry(
@@ -118,7 +116,6 @@ public class ServiceBusTracingImpl implements ServiceBusTracing {
 				duration,
 				successful);
 
-		dependencyTelemetry.setId(dependencyId);
 		dependencyTelemetry.setType(SERVICE_BUS_REMOTE_DEPENDENCY_TYPE);
 		dependencyTelemetry.setTarget(target);
 

--- a/src/shipping/ingestion/src/main/resources/application.yml
+++ b/src/shipping/ingestion/src/main/resources/application.yml
@@ -1,0 +1,5 @@
+management:
+  tracing:
+    enabled: true
+    sampling:
+      probability: 1.0


### PR DESCRIPTION
Includes:
* https://github.com/mspnp/fabrikam-dronedelivery-workload/pull/221  
    It implies code changes. When upgrading from applicationinsights-web version 2.6.4 to 3.7.3 in a Java Spring Boot application, the class com.microsoft.applicationinsights.web.internal.correlation.TelemetryCorrelationUtils has been removed as part of a broader refactor in the Application Insights Java SDK.  
     https://learn.microsoft.com/en-us/azure/azure-monitor/app/distributed-trace-data  
     https://www.baeldung.com/spring-boot-opentelemetry-setup
* https://github.com/mspnp/fabrikam-dronedelivery-workload/pull/220